### PR TITLE
Declare in the catalog endpoint that the broker expects app log streaming

### DIFF
--- a/src/main/java/org/cloudfoundry/community/servicebroker/postgresql/config/BrokerConfiguration.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/postgresql/config/BrokerConfiguration.java
@@ -71,7 +71,7 @@ public class BrokerConfiguration {
     public Catalog catalog() throws JsonParseException, JsonMappingException, IOException {
         ServiceDefinition serviceDefinition = new ServiceDefinition("pg", "PostgreSQL",
                 "PostgreSQL on shared instance.", true, getPlans(), getTags(), getServiceDefinitionMetadata(),
-                null, null);
+                Arrays.asList("syslog_drain"), null);
         return new Catalog(Arrays.asList(serviceDefinition));
     }
 


### PR DESCRIPTION
This fixes the followin error when trying to bind the a Service Broker instance to an app: 
`Server error, status code: 502, error code: 10001, message: The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider.`

It does resolve this matter by declaring in the catalog endpoint that the broker expects app log streaming. 
See here: http://docs.cloudfoundry.org/services/api.html#catalog-mgmt
Found here: https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/aJZkgVl8yRI
